### PR TITLE
Add noThrow option to NetworkLayer advanced options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ Middlewares
   - `prefix` - prefix message (default: `[RELAY-NETWORK] GRAPHQL SERVER ERROR:`)
 - **deferMiddleware** - _experimental_ Right now `deferMiddleware()` just set `defer` as supported option for Relay. So this middleware allow to community play with `defer()` in cases, which was [described by @wincent](https://github.com/facebook/relay/issues/288#issuecomment-199510058).
 
+Advanced options (2nd argument after middlewares)
+===========
+
+RelayNetworkLayer may accept additional options:
+
+```js
+const middlewares = []; // array of middlewares
+const options = {}; // optional advanced options
+const network = new RelayNetworkLayer(middlewares, options);
+```
+
+Available options:
+
+- **noThrow** - EXPERIMENTAL (May be deprecated in the future) set true to not throw when an error response is given by the server, and to instead handle errors in your app code.
+
 ### Example of injecting NetworkLayer with middlewares on the **client side**.
 ```js
 import Relay from 'react-relay';

--- a/src/definition.js
+++ b/src/definition.js
@@ -59,7 +59,8 @@ export type RRNLResponseObject = {
   statusText: string,
   headers: { [name: string]: string },
   url: string,
-  payload: ?GraphQLResponse,
+  data?: any,
+  errors?: GraphQLResponseErrors,
 };
 
 export type RelayClassicRequest = {
@@ -70,4 +71,8 @@ export type RelayClassicRequest = {
   getQueryString: () => string,
   getVariables: () => Object,
   getDebugName: () => string,
+};
+
+export type RRNLOptions = {
+  noThrow: boolean,
 };

--- a/src/relayMutation.js
+++ b/src/relayMutation.js
@@ -26,7 +26,7 @@ export default function mutation(
   }
 
   return fetchWithMiddleware(req)
-    .then(data => relayRequest.resolve({ response: data }))
+    .then(({ data }) => relayRequest.resolve({ response: data }))
     .catch(err => {
       relayRequest.reject(err);
       throw err;

--- a/src/relayNetworkLayer.js
+++ b/src/relayNetworkLayer.js
@@ -5,7 +5,9 @@ import mutation from './relayMutation';
 import fetchWithMiddleware from './fetchWithMiddleware';
 import type { Middleware, RelayClassicRequest } from './definition';
 
-export type RRNLOptions = {};
+export type RRNLOptions = {
+  noThrow: boolean,
+};
 
 export default class RelayNetworkLayer {
   _options: RRNLOptions;
@@ -40,10 +42,10 @@ export default class RelayNetworkLayer {
   }
 
   sendQueries(requests: RelayClassicRequest[]): Promise<any> {
-    return queries(requests, req => fetchWithMiddleware(req, this._middlewares));
+    return queries(requests, req => fetchWithMiddleware(req, this._middlewares, this._options));
   }
 
   sendMutation(request: RelayClassicRequest): Promise<any> {
-    return mutation(request, req => fetchWithMiddleware(req, this._middlewares));
+    return mutation(request, req => fetchWithMiddleware(req, this._middlewares, this._options));
   }
 }

--- a/src/relayQueries.js
+++ b/src/relayQueries.js
@@ -26,7 +26,7 @@ export default function queries(
       };
 
       return fetchWithMiddleware(req)
-        .then(data => relayRequest.resolve({ response: data }))
+        .then(({ data }) => relayRequest.resolve({ response: data }))
         .catch(err => {
           relayRequest.reject(err);
           throw err;


### PR DESCRIPTION
This ensures that no errors are thrown if `noThrow = true`. It brings the same noThrow functionality as: https://github.com/relay-tools/react-relay-network-modern#advanced-options-2nd-argument-after-middlewares

Useful links:

- https://github.com/facebook/relay/issues/1913#issuecomment-418278622